### PR TITLE
Fix GUI worker start method to avoid plotting failures

### DIFF
--- a/meg_qc/miscellaneous/GUI/megqcGUI.py
+++ b/meg_qc/miscellaneous/GUI/megqcGUI.py
@@ -101,6 +101,18 @@ class Worker(QThread):
         self.func    = func
         self.args    = args
         self.process = None  # the multiprocessing.Process
+        # ``multiprocessing.Process`` defaults to the ``fork`` start method on
+        # Unix which clashes with joblib's own process-pool management used in
+        # the plotting pipeline.  Explicitly request the "spawn" context so that
+        # the worker enters a fresh Python interpreter instead of inheriting the
+        # already-forked state from Qt's helper thread.  This prevents the nested
+        # multiprocessing deadlocks that dropped HTML outputs in the GUI.
+        try:
+            self._mp_ctx = multiprocessing.get_context("spawn")
+        except ValueError:
+            # Platforms that do not expose "spawn" (very old Python builds)
+            # still return the default context so the worker keeps functioning.
+            self._mp_ctx = multiprocessing.get_context()
 
     def run(self):
         # 1) notify GUI
@@ -108,7 +120,7 @@ class Worker(QThread):
         start_time = time.time()
 
         # 2) spawn the subprocess
-        self.process = multiprocessing.Process(
+        self.process = self._mp_ctx.Process(
             target=_worker_target,
             args=(self.func, self.args),
         )


### PR DESCRIPTION
## Summary
- create Worker processes from the spawn multiprocessing context to avoid nested fork issues with joblib in the plotting pipeline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe023466d4832680e366b31e6262c3