### PR TITLE
Use spawn start method for GUI worker processes

### DIFF
--- a/meg_qc/miscellaneous/GUI/megqcGUI.py
+++ b/meg_qc/miscellaneous/GUI/megqcGUI.py
@@ -49,6 +49,16 @@ GUI_DIR = Path(__file__).parent
 # PKG_ROOT apunta a la raíz del paquete meg_qc (dos niveles arriba)
 PKG_ROOT = GUI_DIR.parent.parent
 
+# ``multiprocessing.Process`` uses the platform default start method.  On Unix
+# this is ``fork``, but the MEGqc computation functions internally rely on
+# joblib's ``loky`` executor which expects ``spawn`` semantics.  Mixing the two
+# leads to ``resource_tracker`` warnings about leaked temporary folders and the
+# worker process lingering for a couple of seconds after the actual work
+# finished.  Creating subprocesses from an explicit ``spawn`` context keeps the
+# GUI responsive and eliminates the warning without globally changing the start
+# method for third-party code.
+_MP_CONTEXT = multiprocessing.get_context("spawn")
+
 # Rutas a los ficheros
 SETTINGS_PATH = PKG_ROOT / "settings" / "settings.ini"
 INTERNAL_PATH = PKG_ROOT / "settings" / "settings_internal.ini"
@@ -105,12 +115,17 @@ class Worker(QThread):
         # 1) notify GUI
         self.started.emit()
         # 2) spawn the subprocess
-        self.process = multiprocessing.Process(
+        self.process = _MP_CONTEXT.Process(
             target=_worker_target,
             args=(self.func, self.args),
         )
         self.process.start()
-        self.process.join()  # blocks until the child exits
+        try:
+            self.process.join()  # blocks until the child exits
+        finally:
+            close = getattr(self.process, "close", None)
+            if close is not None:
+                close()
 
         # 3) interpret exit code
         if self.process.exitcode == -signal.SIGTERM:


### PR DESCRIPTION
## Summary
- create GUI worker subprocesses from an explicit spawn context to avoid loky resource tracker leaks
- close worker process handles after joining so the GUI can re-enable buttons promptly

## Testing
- python -m compileall meg_qc/miscellaneous/GUI/megqcGUI.py

------
https://chatgpt.com/codex/tasks/task_e_68fe26dd441c8326a5f9a6c549d200d5