### PR TITLE
Handle missing derivative config entities on Windows

### DIFF
--- a/meg_qc/calculation/meg_qc_pipeline.py
+++ b/meg_qc/calculation/meg_qc_pipeline.py
@@ -414,7 +414,17 @@ def check_config_saved_ask_user(dataset):
     #     print('___MEGqc___: ', 'There is already a config file used for this data set. Do you want to use it again?')
     #     #ask user if he wants to use the same config file again
 
-    entities = query_entities(dataset, scope='derivatives')
+    try:
+        entities = query_entities(dataset, scope='derivatives')
+    except TypeError:
+        # ``ancpbids.query.query_entities`` relies on ``query`` returning an iterable.
+        # On Windows, ``query`` can return ``None`` when the derivatives folder does not
+        # exist yet, raising a ``TypeError`` when ``query_entities`` tries to iterate over
+        # the result.  In that situation there are no previous config files to reuse, so
+        # we can safely treat the entity mapping as empty.
+        entities = {}
+    else:
+        entities = entities or {}
 
     # print('___MEGqc___: ', 'entities', entities)
 


### PR DESCRIPTION
## Summary
- guard `check_config_saved_ask_user` against `TypeError` raised by `query_entities` when the derivatives folder is missing
- default to an empty mapping when no derivative entities are returned so the pipeline can continue with defaults

## Testing
- pytest tests -q *(fails: ModuleNotFoundError: No module named 'meg_qc')*


------
https://chatgpt.com/codex/tasks/task_e_6908d693783083269826fde34a37a29c