### PR TITLE
Limit PyQt6 plugins dependency to non-macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pandas>=2.0.3
 plotly==5.24.1
 joblib==1.4.2
 pyqt6
+pyqt6-plugins==6.4.2.2.3; platform_system != "Darwin"
 numba==0.58.1
 psutil==5.9.8
 matplotlib==3.8.4


### PR DESCRIPTION
## Summary
- add a platform marker to the PyQt6 plugins dependency so it is installed only on non-macOS systems

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917360cca288326b4dc4d6439c7a818)