### PR TITLE
Add configurable derivatives output location

### DIFF
--- a/meg_qc/calculation/meg_qc_pipeline.py
+++ b/meg_qc/calculation/meg_qc_pipeline.py
@@ -3,6 +3,7 @@ import gc
 import ancpbids
 from ancpbids.query import query_entities
 from ancpbids import DatasetOptions
+from ancpbids import save_dataset
 import time
 import json
 import sys
@@ -157,6 +158,52 @@ def get_files_list(sid: str, dataset_path: str, dataset):
     # we can also check that final file of path in list of files is same as name in jsons
 
     return list_of_files, entities_per_file
+
+
+def get_derivatives_base_path(dataset_path: str, override_path: Optional[str]) -> str:
+    """
+    Resolve where derivatives should be written.
+
+    Parameters
+    ----------
+    dataset_path : str
+        Path to the source BIDS dataset.
+    override_path : str or None
+        Optional user-provided location for derivatives output.
+
+    Returns
+    -------
+    str
+        Absolute path to the base directory for derivatives.
+    """
+
+    if override_path:
+        derivatives_base = os.path.abspath(override_path)
+    else:
+        derivatives_base = dataset_path
+
+    os.makedirs(derivatives_base, exist_ok=True)
+
+    # Copy dataset_description.json to support downstream tools that load
+    # derivatives from the alternate location without needing write access to
+    # the original dataset directory.
+    src_description = os.path.join(dataset_path, 'dataset_description.json')
+    dst_description = os.path.join(derivatives_base, 'dataset_description.json')
+    if os.path.isfile(src_description) and not os.path.isfile(dst_description):
+        shutil.copy(src_description, dst_description)
+
+    return derivatives_base
+
+
+def write_derivative(dataset, derivative, derivatives_base: str) -> None:
+    """Persist a derivative to ``derivatives_base`` using ancpbids.
+
+    Using :func:`ancpbids.save_dataset` lets us redirect derivative output to a
+    user-writable directory while keeping the dataset graph intact.
+    """
+
+    print('___MEGqc___: ', f'Writing derivatives to: {derivatives_base}')
+    save_dataset(dataset, target_dir=derivatives_base, context_folder=derivative)
 
 
 def create_config_artifact(derivative, config_file_path: str, f_name_to_save: str, all_taken_raw_files: List[str]):
@@ -516,7 +563,8 @@ def process_one_subject(
         dataset,
         dataset_path: str,
         all_qc_params: dict,
-        internal_qc_params: dict
+        internal_qc_params: dict,
+        derivatives_base: str
 ):
     """
     This function processes a single subject. It contains all the code that was
@@ -896,7 +944,7 @@ def process_one_subject(
             print('REMOVING TRASH: FAILED')
 
     # WRITE DERIVATIVE
-    ancpbids.write_derivative(dataset, derivative)
+    write_derivative(dataset, derivative, derivatives_base)
 
 
 
@@ -921,7 +969,8 @@ def process_one_subject_safe(
         dataset,
         dataset_path: str,
         all_qc_params: dict,
-        internal_qc_params: dict):
+        internal_qc_params: dict,
+        derivatives_base: str):
     """Wrapper around :func:`process_one_subject` that catches errors.
 
     Parameters are identical to :func:`process_one_subject`.
@@ -935,6 +984,7 @@ def process_one_subject_safe(
             dataset_path=dataset_path,
             all_qc_params=all_qc_params,
             internal_qc_params=internal_qc_params,
+            derivatives_base=derivatives_base,
         )
         return sub, result
     except Exception as e:  # Catch any error so the parallel job continues
@@ -1052,7 +1102,8 @@ def make_derivative_meg_qc(
         internal_config_file_path: str,
         ds_paths: Union[List[str], str],
         sub_list: Union[List[str], str] = 'all',
-        n_jobs: int = 5  # Number of parallel jobs
+        n_jobs: int = 5,  # Number of parallel jobs
+        derivatives_path: Optional[str] = None
 ):
     start_time = time.time()
 
@@ -1064,9 +1115,8 @@ def make_derivative_meg_qc(
         dataset = ancpbids.load_dataset(dataset_path, DatasetOptions(lazy_loading=True))
         schema = dataset.get_schema()
 
-        derivatives_path = os.path.join(dataset_path, 'derivatives')
-        if not os.path.isdir(derivatives_path):
-            os.mkdir(derivatives_path)
+        derivatives_base = get_derivatives_base_path(dataset_path, derivatives_path)
+        os.makedirs(os.path.join(derivatives_base, 'derivatives'), exist_ok=True)
 
         reuse_config_file_path = check_config_saved_ask_user(dataset)
         if reuse_config_file_path:
@@ -1093,7 +1143,8 @@ def make_derivative_meg_qc(
                 dataset=dataset,
                 dataset_path=dataset_path,
                 all_qc_params=all_qc_params,
-                internal_qc_params=internal_qc_params
+                internal_qc_params=internal_qc_params,
+                derivatives_base=derivatives_base
             )
             for sub in sub_list
         )
@@ -1140,11 +1191,11 @@ def make_derivative_meg_qc(
             add_raw_to_config_json(derivative, reuse_config_file_path, all_subs_raw_files)
 
         # Write the pipeline-level derivative to disk
-        ancpbids.write_derivative(dataset, derivative)
+        write_derivative(dataset, derivative, derivatives_base)
 
         # Save list of excluded subjects
         if excluded_subjects:
-            excl_path = os.path.join(dataset_path, 'derivatives', 'Meg_QC', 'excluded_subjects')
+            excl_path = os.path.join(derivatives_base, 'derivatives', 'Meg_QC', 'excluded_subjects')
             os.makedirs(os.path.dirname(excl_path), exist_ok=True)
             with open(excl_path, 'w', encoding='utf-8') as f:
                 for sub in excluded_subjects:
@@ -1152,7 +1203,7 @@ def make_derivative_meg_qc(
 
         # Generate Global Quality Index reports and group table
         try:
-            generate_gqi_summary(dataset_path, config_file_path)
+            generate_gqi_summary(dataset_path, config_file_path, derivatives_base)
         except Exception as e:
             print("___MEGqc___: Failed to create global quality reports", e)
 

--- a/meg_qc/calculation/metrics/summary_report_GQI.py
+++ b/meg_qc/calculation/metrics/summary_report_GQI.py
@@ -596,7 +596,7 @@ def create_group_metrics_figure(tsv_path: Union[str, os.PathLike], output_png: U
 
 
 
-def generate_gqi_summary(dataset_path: str, config_file: str) -> None:
+def generate_gqi_summary(dataset_path: str, config_file: str, derivatives_base: Optional[str] = None) -> None:
     """Generate Global Quality Index summaries from existing metrics."""
     # Load user configuration to retrieve GQI settings
     qc_params = get_all_config_params(config_file)
@@ -604,8 +604,9 @@ def generate_gqi_summary(dataset_path: str, config_file: str) -> None:
         return
     gqi_params = qc_params.get("GlobalQualityIndex")
 
-    calc_dir = os.path.join(dataset_path, "derivatives", "Meg_QC", "calculation")
-    reports_root = os.path.join(dataset_path, "derivatives", "Meg_QC", "summary_reports")
+    derivatives_root = derivatives_base if derivatives_base else dataset_path
+    calc_dir = os.path.join(derivatives_root, "derivatives", "Meg_QC", "calculation")
+    reports_root = os.path.join(derivatives_root, "derivatives", "Meg_QC", "summary_reports")
     os.makedirs(reports_root, exist_ok=True)
 
     # Create a new attempt folder using incremental numbering

--- a/meg_qc/miscellaneous/GUI/megqcGUI.py
+++ b/meg_qc/miscellaneous/GUI/megqcGUI.py
@@ -714,6 +714,16 @@ class MainWindow(QMainWindow):
         row_lay.addWidget(btn_browse)
         shared.addRow("Data directory:", row)
 
+        self.derivatives_dir = QLineEdit()
+        btn_browse_deriv = QPushButton("Browse")
+        btn_browse_deriv.clicked.connect(lambda: self._browse(self.derivatives_dir))
+        row_deriv = QWidget()
+        row_deriv_lay = QHBoxLayout(row_deriv)
+        row_deriv_lay.setContentsMargins(0, 0, 0, 0)
+        row_deriv_lay.addWidget(self.derivatives_dir)
+        row_deriv_lay.addWidget(btn_browse_deriv)
+        shared.addRow("Derivatives output (optional):", row_deriv)
+
         self.jobs = QSpinBox()
         self.jobs.setRange(-1, os.cpu_count() or 1)
         self.jobs.setValue(-1)
@@ -850,6 +860,7 @@ class MainWindow(QMainWindow):
         # 1) Gather inputs
         data_dir  = self.data_dir.text().strip()
         subs_raw  = self.calc_subs.text().strip()
+        derivatives_dir = self.derivatives_dir.text().strip()
         # If user typed “all” (case-insensitive) or left blank, use the string "all";
         # otherwise split by commas into a list of IDs.
         subs = (
@@ -866,6 +877,7 @@ class MainWindow(QMainWindow):
             data_dir,
             subs,
             n_jobs,
+            derivatives_dir if derivatives_dir else None,
         )
 
         # 3) Create the Worker, hook up signals → log
@@ -930,12 +942,13 @@ class MainWindow(QMainWindow):
         # 1) Gather inputs
         data_dir = self.data_dir.text().strip()
         n_jobs = self.jobs.value()
+        derivatives_dir = self.derivatives_dir.text().strip()
 
         # 2) Build args tuple for make_plots_meg_qc
         # The plotting backend (full or lite) is selected inside
         # ``make_plots_meg_qc`` based on the 'full_html_reports' option in
         # settings.ini.
-        args = (data_dir, n_jobs)
+        args = (data_dir, n_jobs, derivatives_dir if derivatives_dir else None)
 
         # 3) Create Worker and wire signals
         worker = Worker(make_plots_meg_qc, *args)
@@ -985,7 +998,8 @@ class MainWindow(QMainWindow):
     def start_gqi(self):
         """Run Global Quality Index calculation only."""
         data_dir = self.data_dir.text().strip()
-        args = (data_dir, str(SETTINGS_PATH))
+        derivatives_dir = self.derivatives_dir.text().strip()
+        args = (data_dir, str(SETTINGS_PATH), derivatives_dir if derivatives_dir else None)
         worker = Worker(generate_gqi_summary, *args)
         # Prevent concurrent GQI runs; enable again once finished or stopped.
         self.btn_gqi_run.setEnabled(False)

--- a/meg_qc/miscellaneous/examples/run_calculation_module.py
+++ b/meg_qc/miscellaneous/examples/run_calculation_module.py
@@ -6,6 +6,8 @@ from meg_qc.calculation.meg_qc_pipeline import make_derivative_meg_qc
 # ------------------------------------------------------------------
 # Path to the root of your BIDS MEG dataset.
 data_directory = '/home/karelo/Desktop/Development/MEGQC_workshop/datasets/ds003483/'
+# Optional path to store the derivatives folder outside the dataset root.
+derivatives_output = None
 # Path to a INI config file with user-defined parameters.
 config_file_path = '/home/karelo/PycharmProjects/megqc_update/.venv/lib/python3.10/site-packages/meg_qc/settings/settings.ini'
 # Path to a INI config file of internal parameters.
@@ -47,7 +49,8 @@ make_derivative_meg_qc(
     internal_config_file_path,
     data_directory,
     sub_list,
-    n_jobs=n_jobs_to_use
+    n_jobs=n_jobs_to_use,
+    derivatives_path=derivatives_output
 )
 
 end_time = time.time()

--- a/meg_qc/miscellaneous/examples/run_plotting_module.py
+++ b/meg_qc/miscellaneous/examples/run_plotting_module.py
@@ -9,6 +9,8 @@ from meg_qc.plotting.meg_qc_plots import make_plots_meg_qc
 # ------------------------------------------------------------------
 # Path to the root of your BIDS MEG dataset.
 data_directory = '/home/karelo/Desktop/Development/MEGQC_workshop/datasets/ds003483'
+# Optional path to read derivatives from if they were written outside the dataset.
+derivatives_output = None
 # Number of CPU cores you want to use (for example, 4). Use -1 to utilize all available CPU cores:
 n_jobs_to_use = 3
 # ------------------------------------------------------------------
@@ -17,7 +19,7 @@ n_jobs_to_use = 3
 # ------------------------------------------------------------------
 start_time = time.time()
 
-make_plots_meg_qc(data_directory,n_jobs_to_use)
+make_plots_meg_qc(data_directory, n_jobs_to_use, derivatives_path=derivatives_output)
 
 end_time = time.time()
 elapsed_seconds = end_time - start_time

--- a/meg_qc/plotting/meg_qc_plots.py
+++ b/meg_qc/plotting/meg_qc_plots.py
@@ -6,7 +6,7 @@ from prompt_toolkit.shortcuts import checkboxlist_dialog
 from prompt_toolkit.styles import Style
 from collections import defaultdict
 import re
-from typing import List
+from typing import List, Optional
 from pprint import pprint
 import gc
 from ancpbids import DatasetOptions
@@ -668,7 +668,7 @@ def process_subject(
     return
 
 
-def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1):
+def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1, derivatives_path: Optional[str] = None):
     """
     Create plots for the MEG QC pipeline, but WITHOUT the interactive selector.
     Instead, we assume 'all' for every entity (subject, task, session, run, metric).
@@ -680,8 +680,10 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1):
     start_time = time.time()
 
 
+    derivatives_base = os.path.abspath(derivatives_path) if derivatives_path else dataset_path
+
     try:
-        dataset = ancpbids.load_dataset(dataset_path, DatasetOptions(lazy_loading=True))
+        dataset = ancpbids.load_dataset(derivatives_base, DatasetOptions(lazy_loading=True))
         schema = dataset.get_schema()
     except Exception:
         print('___MEGqc___: ',
@@ -689,7 +691,7 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1):
         return
 
     # Make sure the derivatives folder exists:
-    derivatives_path = os.path.join(dataset_path, 'derivatives')
+    derivatives_path = os.path.join(derivatives_base, 'derivatives')
     if not os.path.isdir(derivatives_path):
         os.mkdir(derivatives_path)
         print('___MEGqc___: Derivs folder was not found! Created new.')

--- a/meg_qc/test.py
+++ b/meg_qc/test.py
@@ -102,6 +102,18 @@ def run_megqc():
         )
     )
 
+    dataset_path_parser.add_argument(
+        "--derivatives_path",
+        type=str,
+        required=False,
+        help=(
+            "Optional output root for derivatives.\n"
+            "By default derivatives are written inside the BIDS dataset under\n"
+            "<dataset>/derivatives. Provide a writable alternative directory\n"
+            "to store the 'derivatives' folder elsewhere."
+        )
+    )
+
     # Parse arguments
     args = dataset_path_parser.parse_args()
 
@@ -129,6 +141,10 @@ def run_megqc():
 
     data_directory = args.inputdata
     print("Data directory:", data_directory)
+
+    derivatives_destination = args.derivatives_path
+    if derivatives_destination:
+        print("Derivatives output directory:", os.path.abspath(derivatives_destination))
 
     # Check if --subs was provided
     if args.subs is None:
@@ -182,14 +198,16 @@ def run_megqc():
         internal_config_file_path=internal_config_file_path,
         ds_paths=data_directory,
         sub_list=sub_list,
-        n_jobs=n_jobs_used
+        n_jobs=n_jobs_used,
+        derivatives_path=derivatives_destination
     )
 
     end_time = time.time()
     elapsed_seconds = end_time - start_time
     print(f"MEGqc has completed the calculation of metrics in {elapsed_seconds:.2f} seconds.")
+    deriv_base_print = os.path.abspath(derivatives_destination) if derivatives_destination else data_directory
     print(
-        f"Results can be found in {data_directory}/derivatives/Meg_QC/calculation"
+        f"Results can be found in {deriv_base_print}/derivatives/Meg_QC/calculation"
     )
 
     # ----------------------------------------------------------------
@@ -198,7 +216,7 @@ def run_megqc():
     user_input = input('Do you want to run the MEGqc plotting module on the MEGqc results? (y/n): ').lower().strip() == 'y'
     if user_input:
         from meg_qc.plotting.meg_qc_plots import make_plots_meg_qc
-        make_plots_meg_qc(data_directory)
+        make_plots_meg_qc(data_directory, derivatives_path=derivatives_destination)
         return
     else:
         return
@@ -253,10 +271,16 @@ def get_plots():
         required=True,
         help="Path to the root of your BIDS MEG dataset"
     )
+    dataset_path_parser.add_argument(
+        "--derivatives_path",
+        type=str,
+        required=False,
+        help="Optional output root for derivatives."
+    )
     args = dataset_path_parser.parse_args()
     data_directory = args.inputdata
 
-    make_plots_meg_qc(data_directory)
+    make_plots_meg_qc(data_directory, derivatives_path=args.derivatives_path)
     return
 
 
@@ -279,11 +303,17 @@ def run_gqi():
         required=False,
         help="Path to a config file with GQI parameters",
     )
+    parser.add_argument(
+        "--derivatives_path",
+        type=str,
+        required=False,
+        help="Optional output root for derivatives.",
+    )
     args = parser.parse_args()
 
     install_path = os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir))
     default_config = os.path.join(install_path, "settings", "settings.ini")
     cfg_path = args.config if args.config else default_config
 
-    generate_gqi_summary(args.inputdata, cfg_path)
+    generate_gqi_summary(args.inputdata, cfg_path, args.derivatives_path)
     return


### PR DESCRIPTION
## Summary
- add support for directing MEG QC derivatives to a user-specified base directory
- expose the derivatives output option in the CLI entry point, GUI, and example scripts
- update plotting and GQI utilities to consume derivatives from custom locations

## Testing
- python -m compileall meg_qc

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936b25c6d1883268273b2e294e1d6b5)