### PR TITLE
Ensure temp derivatives honor custom output base

### DIFF
--- a/meg_qc/calculation/initial_meg_qc.py
+++ b/meg_qc/calculation/initial_meg_qc.py
@@ -899,7 +899,12 @@ def sort_channels_by_lobe(channels_objs: dict):
     return chs_by_lobe
 
 
-def save_meg_with_suffix(file_path: str, dataset_path: str, raw, final_suffix: str = "FILTERED") -> str:
+def save_meg_with_suffix(
+        file_path: str,
+        dataset_path: str,
+        raw,
+        final_suffix: str = "FILTERED",
+        derivatives_base: str | None = None) -> str:
     """
     Given the original file_path (MEG data) and an MNE raw object,
     this function creates an output directory based on the file_path
@@ -908,7 +913,8 @@ def save_meg_with_suffix(file_path: str, dataset_path: str, raw, final_suffix: s
     The output directory is constructed as:
         <base_dir>/derivatives/temp/<subject>
     where:
-        - base_dir is the portion of file_path up to ds_name
+        - base_dir is the portion of file_path up to ds_name unless
+          ``derivatives_base`` overrides it
         - subject is the folder immediately after ds_name
           (plus a small offset if 'temp' is in the path)
         - ds_name is extracted from dataset_path (e.g., the basename "ds_orig").
@@ -967,6 +973,12 @@ def save_meg_with_suffix(file_path: str, dataset_path: str, raw, final_suffix: s
         # Linux or relative => replicate your old logic: leading slash
         base_dir = os.path.join(os.sep, *components[:idx + 1])
 
+    # When a custom derivatives base is provided, prefer that over the path
+    # computed from the original dataset. This allows placing temp files
+    # alongside user-specified derivatives while preserving the subject
+    # structure.
+    base_dir = os.path.abspath(derivatives_base) if derivatives_base else base_dir
+
     # 8) Construct the output directory
     output_dir = os.path.join(base_dir, 'derivatives', 'temp', subject)
     output_dir = os.path.abspath(output_dir)
@@ -994,32 +1006,29 @@ def save_meg_with_suffix(file_path: str, dataset_path: str, raw, final_suffix: s
     return new_file_path
 
 
-def delete_temp_folder(dataset_path: str) -> str:
+def delete_temp_folder(derivatives_base: str) -> str:
     """
-    Given the original dataset_path, this function re-creates the temporary written files
-    directory and then delete it.
+    Given the derivatives base path, this function re-creates the temporary
+    written files directory and then deletes it.
 
     The output directory is constructed as:
-         <base_dir>/derivatives/temp/<subject>
-    where:
-         - base_dir is the portion of file_path up to and including 'ds_orig'
-         - subject is the folder immediately after 'ds_orig'
+         <derivatives_base>/derivatives/temp/<subject>
 
     Parameters
     ----------
-    dataset_path : str
-         Absolute path to the dataset folder.
+    derivatives_base : str
+         Absolute path to the derivatives base folder.
     """
-    temp_dir = os.path.join(dataset_path, 'derivatives', 'temp')
+    temp_dir = os.path.join(derivatives_base, 'derivatives', 'temp')
     temp_dir = os.path.abspath(temp_dir)
-    shutil.rmtree(temp_dir)
+    shutil.rmtree(temp_dir, ignore_errors=True)
     print("Removing directory:", temp_dir)
 
     return
 
 
 def initial_processing(default_settings: dict, filtering_settings: dict, epoching_params: dict, file_path: str,
-                       dataset_path: str):
+                       dataset_path: str, derivatives_base: str | None = None):
     """
     Here all the initial actions needed to analyse MEG data are done:
 
@@ -1039,6 +1048,10 @@ def initial_processing(default_settings: dict, filtering_settings: dict, epochin
         Dictionary with parameters for epoching.
     file_path : str
         Path to the fif file with MEG data.
+    derivatives_base : str | None
+        Optional base directory for derivatives and temporary files. When
+        provided, temporary FIF files are written inside this folder instead
+        of the original dataset tree.
 
     Returns
     -------
@@ -1121,7 +1134,13 @@ def initial_processing(default_settings: dict, filtering_settings: dict, epochin
     if filtering_settings['apply_filtering'] is True:
         raw_cropped.load_data()  # Data has to be loaded into mememory before filetering:
         # Save raw_cropped
-        raw_cropped_path = save_meg_with_suffix(file_path, dataset_path, raw_cropped, final_suffix="CROPPED")
+        raw_cropped_path = save_meg_with_suffix(
+            file_path,
+            dataset_path,
+            raw_cropped,
+            final_suffix="CROPPED",
+            derivatives_base=derivatives_base,
+        )
 
         raw_cropped_filtered = raw_cropped
 
@@ -1138,8 +1157,13 @@ def initial_processing(default_settings: dict, filtering_settings: dict, epochin
               'Hz.')
 
         # Save filtered signal
-        raw_cropped_filtered_path = save_meg_with_suffix(file_path, dataset_path, raw_cropped_filtered,
-                                                         final_suffix="FILTERED")
+        raw_cropped_filtered_path = save_meg_with_suffix(
+            file_path,
+            dataset_path,
+            raw_cropped_filtered,
+            final_suffix="FILTERED",
+            derivatives_base=derivatives_base,
+        )
 
         if filtering_settings['downsample_to_hz'] is False:
             raw_cropped_filtered_resampled = raw_cropped_filtered
@@ -1148,16 +1172,24 @@ def initial_processing(default_settings: dict, filtering_settings: dict, epochin
             print('___MEGqc___: ', resample_str)
         elif filtering_settings['downsample_to_hz'] >= filtering_settings['h_freq'] * 5:
             raw_cropped_filtered_resampled = raw_cropped_filtered.resample(sfreq=filtering_settings['downsample_to_hz'])
-            raw_cropped_filtered_resampled_path = save_meg_with_suffix(file_path, dataset_path,
-                                                                       raw_cropped_filtered_resampled,
-                                                                       final_suffix="FILTERED_RESAMPLED")
+            raw_cropped_filtered_resampled_path = save_meg_with_suffix(
+                file_path,
+                dataset_path,
+                raw_cropped_filtered_resampled,
+                final_suffix="FILTERED_RESAMPLED",
+                derivatives_base=derivatives_base,
+            )
             resample_str = 'Data resampled to ' + str(filtering_settings['downsample_to_hz']) + ' Hz. '
             print('___MEGqc___: ', resample_str)
         else:
             raw_cropped_filtered_resampled = raw_cropped_filtered.resample(sfreq=filtering_settings['h_freq'] * 5)
-            raw_cropped_filtered_resampled_path = save_meg_with_suffix(file_path, dataset_path,
-                                                                       raw_cropped_filtered_resampled,
-                                                                       final_suffix="FILTERED_RESAMPLED")
+            raw_cropped_filtered_resampled_path = save_meg_with_suffix(
+                file_path,
+                dataset_path,
+                raw_cropped_filtered_resampled,
+                final_suffix="FILTERED_RESAMPLED",
+                derivatives_base=derivatives_base,
+            )
             # frequency to resample is 5 times higher than the maximum chosen frequency of the function
             resample_str = 'Chosen "downsample_to_hz" value set was too low, it must be at least 5 time higher than the highest filer frequency. Data resampled to ' + str(
                 filtering_settings['h_freq'] * 5) + ' Hz. '
@@ -1169,9 +1201,13 @@ def initial_processing(default_settings: dict, filtering_settings: dict, epochin
         # And downsample:
         if filtering_settings['downsample_to_hz'] is not False:
             raw_cropped_filtered_resampled = raw_cropped_filtered.resample(sfreq=filtering_settings['downsample_to_hz'])
-            raw_cropped_filtered_resampled_path = save_meg_with_suffix(file_path, dataset_path,
-                                                                       raw_cropped_filtered_resampled,
-                                                                       final_suffix="FILTERED_RESAMPLED")
+            raw_cropped_filtered_resampled_path = save_meg_with_suffix(
+                file_path,
+                dataset_path,
+                raw_cropped_filtered_resampled,
+                final_suffix="FILTERED_RESAMPLED",
+                derivatives_base=derivatives_base,
+            )
             if filtering_settings['downsample_to_hz'] < 500:
                 resample_str = 'Data resampled to ' + str(filtering_settings[
                                                               'downsample_to_hz']) + ' Hz. Keep in mind: resampling to less than 500Hz is not recommended, since it might result in high frequency data loss (for example of the CHPI coils signal. '
@@ -1181,9 +1217,13 @@ def initial_processing(default_settings: dict, filtering_settings: dict, epochin
                 print('___MEGqc___: ', resample_str)
         else:
             raw_cropped_filtered_resampled = raw_cropped_filtered
-            raw_cropped_filtered_resampled_path = save_meg_with_suffix(file_path, dataset_path,
-                                                                       raw_cropped_filtered_resampled,
-                                                                       final_suffix="FILTERED_RESAMPLED")
+            raw_cropped_filtered_resampled_path = save_meg_with_suffix(
+                file_path,
+                dataset_path,
+                raw_cropped_filtered_resampled,
+                final_suffix="FILTERED_RESAMPLED",
+                derivatives_base=derivatives_base,
+            )
             resample_str = 'Data not resampled. '
             print('___MEGqc___: ', resample_str)
 

--- a/meg_qc/calculation/metrics/summary_report_GQI.py
+++ b/meg_qc/calculation/metrics/summary_report_GQI.py
@@ -596,7 +596,7 @@ def create_group_metrics_figure(tsv_path: Union[str, os.PathLike], output_png: U
 
 
 
-def generate_gqi_summary(dataset_path: str, config_file: str) -> None:
+def generate_gqi_summary(dataset_path: str, config_file: str, derivatives_base: Optional[str] = None) -> None:
     """Generate Global Quality Index summaries from existing metrics."""
     # Load user configuration to retrieve GQI settings
     qc_params = get_all_config_params(config_file)
@@ -604,8 +604,9 @@ def generate_gqi_summary(dataset_path: str, config_file: str) -> None:
         return
     gqi_params = qc_params.get("GlobalQualityIndex")
 
-    calc_dir = os.path.join(dataset_path, "derivatives", "Meg_QC", "calculation")
-    reports_root = os.path.join(dataset_path, "derivatives", "Meg_QC", "summary_reports")
+    derivatives_root = derivatives_base if derivatives_base else dataset_path
+    calc_dir = os.path.join(derivatives_root, "derivatives", "Meg_QC", "calculation")
+    reports_root = os.path.join(derivatives_root, "derivatives", "Meg_QC", "summary_reports")
     os.makedirs(reports_root, exist_ok=True)
 
     # Create a new attempt folder using incremental numbering

--- a/meg_qc/miscellaneous/GUI/megqcGUI.py
+++ b/meg_qc/miscellaneous/GUI/megqcGUI.py
@@ -714,6 +714,16 @@ class MainWindow(QMainWindow):
         row_lay.addWidget(btn_browse)
         shared.addRow("Data directory:", row)
 
+        self.derivatives_dir = QLineEdit()
+        btn_browse_deriv = QPushButton("Browse")
+        btn_browse_deriv.clicked.connect(lambda: self._browse(self.derivatives_dir))
+        row_deriv = QWidget()
+        row_deriv_lay = QHBoxLayout(row_deriv)
+        row_deriv_lay.setContentsMargins(0, 0, 0, 0)
+        row_deriv_lay.addWidget(self.derivatives_dir)
+        row_deriv_lay.addWidget(btn_browse_deriv)
+        shared.addRow("Derivatives output (optional):", row_deriv)
+
         self.jobs = QSpinBox()
         self.jobs.setRange(-1, os.cpu_count() or 1)
         self.jobs.setValue(-1)
@@ -850,6 +860,7 @@ class MainWindow(QMainWindow):
         # 1) Gather inputs
         data_dir  = self.data_dir.text().strip()
         subs_raw  = self.calc_subs.text().strip()
+        derivatives_dir = self.derivatives_dir.text().strip()
         # If user typed “all” (case-insensitive) or left blank, use the string "all";
         # otherwise split by commas into a list of IDs.
         subs = (
@@ -866,6 +877,7 @@ class MainWindow(QMainWindow):
             data_dir,
             subs,
             n_jobs,
+            derivatives_dir if derivatives_dir else None,
         )
 
         # 3) Create the Worker, hook up signals → log
@@ -930,12 +942,13 @@ class MainWindow(QMainWindow):
         # 1) Gather inputs
         data_dir = self.data_dir.text().strip()
         n_jobs = self.jobs.value()
+        derivatives_dir = self.derivatives_dir.text().strip()
 
         # 2) Build args tuple for make_plots_meg_qc
         # The plotting backend (full or lite) is selected inside
         # ``make_plots_meg_qc`` based on the 'full_html_reports' option in
         # settings.ini.
-        args = (data_dir, n_jobs)
+        args = (data_dir, n_jobs, derivatives_dir if derivatives_dir else None)
 
         # 3) Create Worker and wire signals
         worker = Worker(make_plots_meg_qc, *args)
@@ -985,7 +998,8 @@ class MainWindow(QMainWindow):
     def start_gqi(self):
         """Run Global Quality Index calculation only."""
         data_dir = self.data_dir.text().strip()
-        args = (data_dir, str(SETTINGS_PATH))
+        derivatives_dir = self.derivatives_dir.text().strip()
+        args = (data_dir, str(SETTINGS_PATH), derivatives_dir if derivatives_dir else None)
         worker = Worker(generate_gqi_summary, *args)
         # Prevent concurrent GQI runs; enable again once finished or stopped.
         self.btn_gqi_run.setEnabled(False)

--- a/meg_qc/miscellaneous/examples/run_calculation_module.py
+++ b/meg_qc/miscellaneous/examples/run_calculation_module.py
@@ -6,6 +6,8 @@ from meg_qc.calculation.meg_qc_pipeline import make_derivative_meg_qc
 # ------------------------------------------------------------------
 # Path to the root of your BIDS MEG dataset.
 data_directory = '/home/karelo/Desktop/Development/MEGQC_workshop/datasets/ds003483/'
+# Optional path to store the derivatives folder outside the dataset root.
+derivatives_output = None
 # Path to a INI config file with user-defined parameters.
 config_file_path = '/home/karelo/PycharmProjects/megqc_update/.venv/lib/python3.10/site-packages/meg_qc/settings/settings.ini'
 # Path to a INI config file of internal parameters.
@@ -47,7 +49,8 @@ make_derivative_meg_qc(
     internal_config_file_path,
     data_directory,
     sub_list,
-    n_jobs=n_jobs_to_use
+    n_jobs=n_jobs_to_use,
+    derivatives_path=derivatives_output
 )
 
 end_time = time.time()

--- a/meg_qc/miscellaneous/examples/run_plotting_module.py
+++ b/meg_qc/miscellaneous/examples/run_plotting_module.py
@@ -9,6 +9,8 @@ from meg_qc.plotting.meg_qc_plots import make_plots_meg_qc
 # ------------------------------------------------------------------
 # Path to the root of your BIDS MEG dataset.
 data_directory = '/home/karelo/Desktop/Development/MEGQC_workshop/datasets/ds003483'
+# Optional path to read derivatives from if they were written outside the dataset.
+derivatives_output = None
 # Number of CPU cores you want to use (for example, 4). Use -1 to utilize all available CPU cores:
 n_jobs_to_use = 3
 # ------------------------------------------------------------------
@@ -17,7 +19,7 @@ n_jobs_to_use = 3
 # ------------------------------------------------------------------
 start_time = time.time()
 
-make_plots_meg_qc(data_directory,n_jobs_to_use)
+make_plots_meg_qc(data_directory, n_jobs_to_use, derivatives_path=derivatives_output)
 
 end_time = time.time()
 elapsed_seconds = end_time - start_time

--- a/meg_qc/plotting/meg_qc_plots.py
+++ b/meg_qc/plotting/meg_qc_plots.py
@@ -6,7 +6,7 @@ from prompt_toolkit.shortcuts import checkboxlist_dialog
 from prompt_toolkit.styles import Style
 from collections import defaultdict
 import re
-from typing import List
+from typing import List, Optional
 from pprint import pprint
 import gc
 from ancpbids import DatasetOptions
@@ -668,7 +668,7 @@ def process_subject(
     return
 
 
-def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1):
+def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1, derivatives_path: Optional[str] = None):
     """
     Create plots for the MEG QC pipeline, but WITHOUT the interactive selector.
     Instead, we assume 'all' for every entity (subject, task, session, run, metric).
@@ -680,8 +680,10 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1):
     start_time = time.time()
 
 
+    derivatives_base = os.path.abspath(derivatives_path) if derivatives_path else dataset_path
+
     try:
-        dataset = ancpbids.load_dataset(dataset_path, DatasetOptions(lazy_loading=True))
+        dataset = ancpbids.load_dataset(derivatives_base, DatasetOptions(lazy_loading=True))
         schema = dataset.get_schema()
     except Exception:
         print('___MEGqc___: ',
@@ -689,7 +691,7 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1):
         return
 
     # Make sure the derivatives folder exists:
-    derivatives_path = os.path.join(dataset_path, 'derivatives')
+    derivatives_path = os.path.join(derivatives_base, 'derivatives')
     if not os.path.isdir(derivatives_path):
         os.mkdir(derivatives_path)
         print('___MEGqc___: Derivs folder was not found! Created new.')

--- a/meg_qc/test.py
+++ b/meg_qc/test.py
@@ -102,6 +102,18 @@ def run_megqc():
         )
     )
 
+    dataset_path_parser.add_argument(
+        "--derivatives_path",
+        type=str,
+        required=False,
+        help=(
+            "Optional output root for derivatives.\n"
+            "By default derivatives are written inside the BIDS dataset under\n"
+            "<dataset>/derivatives. Provide a writable alternative directory\n"
+            "to store the 'derivatives' folder elsewhere."
+        )
+    )
+
     # Parse arguments
     args = dataset_path_parser.parse_args()
 
@@ -129,6 +141,10 @@ def run_megqc():
 
     data_directory = args.inputdata
     print("Data directory:", data_directory)
+
+    derivatives_destination = args.derivatives_path
+    if derivatives_destination:
+        print("Derivatives output directory:", os.path.abspath(derivatives_destination))
 
     # Check if --subs was provided
     if args.subs is None:
@@ -182,14 +198,16 @@ def run_megqc():
         internal_config_file_path=internal_config_file_path,
         ds_paths=data_directory,
         sub_list=sub_list,
-        n_jobs=n_jobs_used
+        n_jobs=n_jobs_used,
+        derivatives_path=derivatives_destination
     )
 
     end_time = time.time()
     elapsed_seconds = end_time - start_time
     print(f"MEGqc has completed the calculation of metrics in {elapsed_seconds:.2f} seconds.")
+    deriv_base_print = os.path.abspath(derivatives_destination) if derivatives_destination else data_directory
     print(
-        f"Results can be found in {data_directory}/derivatives/Meg_QC/calculation"
+        f"Results can be found in {deriv_base_print}/derivatives/Meg_QC/calculation"
     )
 
     # ----------------------------------------------------------------
@@ -198,7 +216,7 @@ def run_megqc():
     user_input = input('Do you want to run the MEGqc plotting module on the MEGqc results? (y/n): ').lower().strip() == 'y'
     if user_input:
         from meg_qc.plotting.meg_qc_plots import make_plots_meg_qc
-        make_plots_meg_qc(data_directory)
+        make_plots_meg_qc(data_directory, derivatives_path=derivatives_destination)
         return
     else:
         return
@@ -253,10 +271,16 @@ def get_plots():
         required=True,
         help="Path to the root of your BIDS MEG dataset"
     )
+    dataset_path_parser.add_argument(
+        "--derivatives_path",
+        type=str,
+        required=False,
+        help="Optional output root for derivatives."
+    )
     args = dataset_path_parser.parse_args()
     data_directory = args.inputdata
 
-    make_plots_meg_qc(data_directory)
+    make_plots_meg_qc(data_directory, derivatives_path=args.derivatives_path)
     return
 
 
@@ -279,11 +303,17 @@ def run_gqi():
         required=False,
         help="Path to a config file with GQI parameters",
     )
+    parser.add_argument(
+        "--derivatives_path",
+        type=str,
+        required=False,
+        help="Optional output root for derivatives.",
+    )
     args = parser.parse_args()
 
     install_path = os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir))
     default_config = os.path.join(install_path, "settings", "settings.ini")
     cfg_path = args.config if args.config else default_config
 
-    generate_gqi_summary(args.inputdata, cfg_path)
+    generate_gqi_summary(args.inputdata, cfg_path, args.derivatives_path)
     return


### PR DESCRIPTION
## Summary
- ensure derivative overrides create dataset-named folders so outputs stay grouped when written outside the BIDS tree
- route temporary preprocessing files through the resolved derivatives base so custom locations receive intermediate FIFs
- clean up temporary derivative folders using the resolved base directory

## Testing
- python -m compileall meg_qc
