### PR TITLE
Ensure muscle artifacts use external derivatives temp path

### DIFF
--- a/meg_qc/calculation/meg_qc_pipeline.py
+++ b/meg_qc/calculation/meg_qc_pipeline.py
@@ -44,9 +44,53 @@ from meg_qc.calculation.metrics.muscle_meg_qc import MUSCLE_meg_qc
 import os
 import json
 import pandas as pd
-from typing import Union, Optional, Dict
+from typing import Union, Optional, Dict, Tuple
+from contextlib import contextmanager
 
 from meg_qc.calculation.metrics.summary_report_GQI import generate_gqi_summary
+
+
+def resolve_output_roots(dataset_path: str, external_derivatives_root: Optional[str]) -> Tuple[str, str]:
+    """Return the dataset output root and derivatives folder respecting overrides.
+
+    Parameters
+    ----------
+    dataset_path : str
+        Path to the original BIDS dataset.
+    external_derivatives_root : Optional[str]
+        User-provided folder in which a dataset-named directory will be created
+        to host derivatives. If ``None`` the derivatives live inside the
+        original dataset.
+
+    Returns
+    -------
+    tuple
+        ``(output_root, derivatives_root)`` where ``output_root`` is the base
+        dataset directory used when writing derivatives and ``derivatives_root``
+        points to the "derivatives" folder inside ``output_root``.
+    """
+
+    ds_name = os.path.basename(os.path.normpath(dataset_path))
+    output_root = dataset_path if external_derivatives_root is None else os.path.join(external_derivatives_root, ds_name)
+    derivatives_root = os.path.join(output_root, 'derivatives')
+    os.makedirs(derivatives_root, exist_ok=True)
+    return output_root, derivatives_root
+
+
+@contextmanager
+def temporary_dataset_base(dataset, base_dir: str):
+    """Temporarily point an ANCPBIDS dataset to a different base directory.
+
+    This is used to redirect derivative writing without interfering with how
+    raw files are located inside the original BIDS dataset.
+    """
+
+    original_base = getattr(dataset, 'base_dir_', None)
+    dataset.base_dir_ = base_dir
+    try:
+        yield
+    finally:
+        dataset.base_dir_ = original_base
 
 def ctf_workaround(dataset, sid):
     artifacts = dataset.query(suffix="meg", return_type="object", subj=sid, scope='raw')
@@ -516,7 +560,9 @@ def process_one_subject(
         dataset,
         dataset_path: str,
         all_qc_params: dict,
-        internal_qc_params: dict
+        internal_qc_params: dict,
+        derivatives_root: str,
+        output_root: str
 ):
     """
     This function processes a single subject. It contains all the code that was
@@ -534,6 +580,11 @@ def process_one_subject(
         QC parameters from user config file.
     internal_qc_params : dict
         Internal QC parameters that users do not change.
+    derivatives_root : str
+        Path to the derivatives directory where outputs should be written.
+    output_root : str
+        Base directory used when persisting derivatives (parent of the
+        derivatives folder), allowing redirection outside the BIDS dataset.
     """
 
     # We replicate everything that was inside the loop.
@@ -608,7 +659,7 @@ def process_one_subject(
             filtering_settings=all_qc_params['Filtering'],
             epoching_params=all_qc_params['Epoching'],
             file_path=data_file,
-            dataset_path=dataset_path
+            derivatives_root=derivatives_root
         )
 
         print('___MEGqc___: ',
@@ -777,7 +828,7 @@ def process_one_subject(
                 raw_cropped_filtered,
                 noisy_freqs_global,
                 m_or_g_chosen,
-                dataset_path,
+                derivatives_root,
                 attach_dummy=True,
                 cut_dummy=True
             )
@@ -896,7 +947,8 @@ def process_one_subject(
             print('REMOVING TRASH: FAILED')
 
     # WRITE DERIVATIVE
-    ancpbids.write_derivative(dataset, derivative)
+    with temporary_dataset_base(dataset, output_root):
+        ancpbids.write_derivative(dataset, derivative)
 
 
 
@@ -921,7 +973,9 @@ def process_one_subject_safe(
         dataset,
         dataset_path: str,
         all_qc_params: dict,
-        internal_qc_params: dict):
+        internal_qc_params: dict,
+        derivatives_root: str,
+        output_root: str):
     """Wrapper around :func:`process_one_subject` that catches errors.
 
     Parameters are identical to :func:`process_one_subject`.
@@ -935,6 +989,8 @@ def process_one_subject_safe(
             dataset_path=dataset_path,
             all_qc_params=all_qc_params,
             internal_qc_params=internal_qc_params,
+            derivatives_root=derivatives_root,
+            output_root=output_root,
         )
         return sub, result
     except Exception as e:  # Catch any error so the parallel job continues
@@ -1052,7 +1108,8 @@ def make_derivative_meg_qc(
         internal_config_file_path: str,
         ds_paths: Union[List[str], str],
         sub_list: Union[List[str], str] = 'all',
-        n_jobs: int = 5  # Number of parallel jobs
+        n_jobs: int = 5,  # Number of parallel jobs
+        derivatives_base: Optional[str] = None
 ):
     start_time = time.time()
 
@@ -1064,11 +1121,10 @@ def make_derivative_meg_qc(
         dataset = ancpbids.load_dataset(dataset_path, DatasetOptions(lazy_loading=True))
         schema = dataset.get_schema()
 
-        derivatives_path = os.path.join(dataset_path, 'derivatives')
-        if not os.path.isdir(derivatives_path):
-            os.mkdir(derivatives_path)
+        output_root, derivatives_root = resolve_output_roots(dataset_path, derivatives_base)
 
-        reuse_config_file_path = check_config_saved_ask_user(dataset)
+        with temporary_dataset_base(dataset, output_root):
+            reuse_config_file_path = check_config_saved_ask_user(dataset)
         if reuse_config_file_path:
             config_file_path = reuse_config_file_path
         else:
@@ -1093,7 +1149,9 @@ def make_derivative_meg_qc(
                 dataset=dataset,
                 dataset_path=dataset_path,
                 all_qc_params=all_qc_params,
-                internal_qc_params=internal_qc_params
+                internal_qc_params=internal_qc_params,
+                derivatives_root=derivatives_root,
+                output_root=output_root
             )
             for sub in sub_list
         )
@@ -1121,7 +1179,7 @@ def make_derivative_meg_qc(
         excluded_subjects = [sub for sub, files in results if files is None]
 
         # Remove temporary folder of intermediate files
-        delete_temp_folder(dataset_path)
+        delete_temp_folder(derivatives_root)
 
         # Save config file used for this run as a derivative:
         all_subs_raw_files = []
@@ -1140,11 +1198,12 @@ def make_derivative_meg_qc(
             add_raw_to_config_json(derivative, reuse_config_file_path, all_subs_raw_files)
 
         # Write the pipeline-level derivative to disk
-        ancpbids.write_derivative(dataset, derivative)
+        with temporary_dataset_base(dataset, output_root):
+            ancpbids.write_derivative(dataset, derivative)
 
         # Save list of excluded subjects
         if excluded_subjects:
-            excl_path = os.path.join(dataset_path, 'derivatives', 'Meg_QC', 'excluded_subjects')
+            excl_path = os.path.join(derivatives_root, 'Meg_QC', 'excluded_subjects')
             os.makedirs(os.path.dirname(excl_path), exist_ok=True)
             with open(excl_path, 'w', encoding='utf-8') as f:
                 for sub in excluded_subjects:
@@ -1152,7 +1211,7 @@ def make_derivative_meg_qc(
 
         # Generate Global Quality Index reports and group table
         try:
-            generate_gqi_summary(dataset_path, config_file_path)
+            generate_gqi_summary(dataset_path, derivatives_root, config_file_path)
         except Exception as e:
             print("___MEGqc___: Failed to create global quality reports", e)
 

--- a/meg_qc/calculation/metrics/summary_report_GQI.py
+++ b/meg_qc/calculation/metrics/summary_report_GQI.py
@@ -596,7 +596,7 @@ def create_group_metrics_figure(tsv_path: Union[str, os.PathLike], output_png: U
 
 
 
-def generate_gqi_summary(dataset_path: str, config_file: str) -> None:
+def generate_gqi_summary(dataset_path: str, derivatives_root: str, config_file: str) -> None:
     """Generate Global Quality Index summaries from existing metrics."""
     # Load user configuration to retrieve GQI settings
     qc_params = get_all_config_params(config_file)
@@ -604,8 +604,8 @@ def generate_gqi_summary(dataset_path: str, config_file: str) -> None:
         return
     gqi_params = qc_params.get("GlobalQualityIndex")
 
-    calc_dir = os.path.join(dataset_path, "derivatives", "Meg_QC", "calculation")
-    reports_root = os.path.join(dataset_path, "derivatives", "Meg_QC", "summary_reports")
+    calc_dir = os.path.join(derivatives_root, "Meg_QC", "calculation")
+    reports_root = os.path.join(derivatives_root, "Meg_QC", "summary_reports")
     os.makedirs(reports_root, exist_ok=True)
 
     # Create a new attempt folder using incremental numbering

--- a/meg_qc/miscellaneous/GUI/megqcGUI.py
+++ b/meg_qc/miscellaneous/GUI/megqcGUI.py
@@ -714,6 +714,17 @@ class MainWindow(QMainWindow):
         row_lay.addWidget(btn_browse)
         shared.addRow("Data directory:", row)
 
+        # Optional external derivatives directory
+        self.derivatives_dir = QLineEdit()
+        derivatives_browse = QPushButton("Browse")
+        derivatives_browse.clicked.connect(lambda: self._browse(self.derivatives_dir))
+        deriv_row = QWidget()
+        deriv_lay = QHBoxLayout(deriv_row)
+        deriv_lay.setContentsMargins(0, 0, 0, 0)
+        deriv_lay.addWidget(self.derivatives_dir)
+        deriv_lay.addWidget(derivatives_browse)
+        shared.addRow("Derivatives output (optional):", deriv_row)
+
         self.jobs = QSpinBox()
         self.jobs.setRange(-1, os.cpu_count() or 1)
         self.jobs.setValue(-1)
@@ -849,6 +860,7 @@ class MainWindow(QMainWindow):
         """
         # 1) Gather inputs
         data_dir  = self.data_dir.text().strip()
+        derivatives_dir = self.derivatives_dir.text().strip() or None
         subs_raw  = self.calc_subs.text().strip()
         # If user typed “all” (case-insensitive) or left blank, use the string "all";
         # otherwise split by commas into a list of IDs.
@@ -859,13 +871,14 @@ class MainWindow(QMainWindow):
         )
         n_jobs = self.jobs.value()
 
-        # 2) Match the signature: (settings_path, internal_path, data_dir, subs, n_jobs)
+        # 2) Match the signature: (settings_path, internal_path, data_dir, subs, n_jobs, derivatives_base)
         args = (
             str(SETTINGS_PATH),
             str(INTERNAL_PATH),
             data_dir,
             subs,
             n_jobs,
+            derivatives_dir,
         )
 
         # 3) Create the Worker, hook up signals → log
@@ -929,13 +942,14 @@ class MainWindow(QMainWindow):
         """
         # 1) Gather inputs
         data_dir = self.data_dir.text().strip()
+        derivatives_dir = self.derivatives_dir.text().strip() or None
         n_jobs = self.jobs.value()
 
         # 2) Build args tuple for make_plots_meg_qc
         # The plotting backend (full or lite) is selected inside
         # ``make_plots_meg_qc`` based on the 'full_html_reports' option in
         # settings.ini.
-        args = (data_dir, n_jobs)
+        args = (data_dir, n_jobs, derivatives_dir)
 
         # 3) Create Worker and wire signals
         worker = Worker(make_plots_meg_qc, *args)
@@ -985,7 +999,8 @@ class MainWindow(QMainWindow):
     def start_gqi(self):
         """Run Global Quality Index calculation only."""
         data_dir = self.data_dir.text().strip()
-        args = (data_dir, str(SETTINGS_PATH))
+        derivatives_dir = self.derivatives_dir.text().strip() or None
+        args = (data_dir, derivatives_dir, str(SETTINGS_PATH))
         worker = Worker(generate_gqi_summary, *args)
         # Prevent concurrent GQI runs; enable again once finished or stopped.
         self.btn_gqi_run.setEnabled(False)

--- a/meg_qc/miscellaneous/examples/run_calculation_module.py
+++ b/meg_qc/miscellaneous/examples/run_calculation_module.py
@@ -15,6 +15,11 @@ internal_config_file_path = '/home/karelo/PycharmProjects/megqc_update/.venv/lib
 sub_list = ['009']
 # sub_list = ['009','012','013','014','015']
 
+# Optional external derivatives root. If provided, MEGqc writes outputs to
+# <derivatives_output_path>/<dataset_name>/derivatives instead of the input
+# dataset directory.
+derivatives_output_path = None
+
 # Number of CPU cores you want to use (for example, 4). Use -1 to utilize all available CPU cores:
 n_jobs_to_use = 1
 # Number of parallel jobs to use during processing.
@@ -47,7 +52,8 @@ make_derivative_meg_qc(
     internal_config_file_path,
     data_directory,
     sub_list,
-    n_jobs=n_jobs_to_use
+    n_jobs=n_jobs_to_use,
+    derivatives_base=derivatives_output_path
 )
 
 end_time = time.time()

--- a/meg_qc/miscellaneous/examples/run_plotting_module.py
+++ b/meg_qc/miscellaneous/examples/run_plotting_module.py
@@ -9,6 +9,8 @@ from meg_qc.plotting.meg_qc_plots import make_plots_meg_qc
 # ------------------------------------------------------------------
 # Path to the root of your BIDS MEG dataset.
 data_directory = '/home/karelo/Desktop/Development/MEGQC_workshop/datasets/ds003483'
+# Optional external derivatives root for plotting results
+derivatives_output_path = None
 # Number of CPU cores you want to use (for example, 4). Use -1 to utilize all available CPU cores:
 n_jobs_to_use = 3
 # ------------------------------------------------------------------
@@ -17,7 +19,7 @@ n_jobs_to_use = 3
 # ------------------------------------------------------------------
 start_time = time.time()
 
-make_plots_meg_qc(data_directory,n_jobs_to_use)
+make_plots_meg_qc(data_directory, n_jobs_to_use, derivatives_output_path)
 
 end_time = time.time()
 elapsed_seconds = end_time - start_time

--- a/meg_qc/miscellaneous/optimizations/artifact_detection_ancp.py
+++ b/meg_qc/miscellaneous/optimizations/artifact_detection_ancp.py
@@ -33,7 +33,7 @@ from mne.utils import _mask_to_onsets_offsets, _pl, _validate_type, logger, verb
 @verbose
 def annotate_muscle_zscore(
     raw_muscle_path,
-    dataset_path,
+    derivatives_root,
     threshold=4,
     ch_type=None,
     min_length_good=0.1,
@@ -57,6 +57,8 @@ def annotate_muscle_zscore(
     ----------
     raw : instance of Raw
         Data to estimate segments with muscle artifacts.
+    derivatives_root : str
+        Base derivatives directory where temporary files should be written.
     threshold : float
         The threshold in z-scores for marking segments as containing muscle
         activity artifacts.
@@ -125,7 +127,12 @@ def annotate_muscle_zscore(
     sfreq = raw_copy.info["sfreq"]
 
     # Save annotated muscle filtered
-    raw_annotated_muscle_path = save_meg_with_suffix(raw_muscle_path, dataset_path, raw_copy, final_suffix="ANNOTATED_MUSCLE_FILTERED")
+    raw_annotated_muscle_path = save_meg_with_suffix(
+        raw_muscle_path,
+        derivatives_root,
+        raw_copy,
+        final_suffix="ANNOTATED_MUSCLE_FILTERED",
+    )
     # Clean filtered
     del raw_copy
     gc.collect()

--- a/meg_qc/plotting/meg_qc_plots.py
+++ b/meg_qc/plotting/meg_qc_plots.py
@@ -13,6 +13,8 @@ from ancpbids import DatasetOptions
 import configparser
 from pathlib import Path
 import time
+from typing import Tuple, Optional
+from contextlib import contextmanager
 
 # Get the absolute path of the parent directory of the current script
 parent_dir = os.path.dirname(os.getcwd())
@@ -74,6 +76,28 @@ def _load_plotting_backend():
 
 
 _load_plotting_backend()
+
+
+def resolve_output_roots(dataset_path: str, external_derivatives_root: Optional[str]) -> Tuple[str, str]:
+    """Return dataset output root and derivatives folder respecting overrides."""
+
+    ds_name = os.path.basename(os.path.normpath(dataset_path))
+    output_root = dataset_path if external_derivatives_root is None else os.path.join(external_derivatives_root, ds_name)
+    derivatives_root = os.path.join(output_root, 'derivatives')
+    os.makedirs(derivatives_root, exist_ok=True)
+    return output_root, derivatives_root
+
+
+@contextmanager
+def temporary_dataset_base(dataset, base_dir: str):
+    """Temporarily repoint the ANCPBIDS dataset to a new base directory."""
+
+    original_base = getattr(dataset, 'base_dir_', None)
+    dataset.base_dir_ = base_dir
+    try:
+        yield
+    finally:
+        dataset.base_dir_ = original_base
 
 # IMPORTANT: keep this order of imports, first need to add parent dir to sys.path, then import from it.
 
@@ -664,11 +688,12 @@ def process_subject(
                 lambda file_path, cont=summary_html: open(file_path, "w", encoding="utf-8").write(cont)
             )
 
-    ancpbids.write_derivative(dataset, derivative)
+    with temporary_dataset_base(dataset, output_root):
+        ancpbids.write_derivative(dataset, derivative)
     return
 
 
-def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1):
+def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1, derivatives_base: Optional[str] = None):
     """
     Create plots for the MEG QC pipeline, but WITHOUT the interactive selector.
     Instead, we assume 'all' for every entity (subject, task, session, run, metric).
@@ -688,11 +713,7 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1):
               'No data found in the given directory path! \nCheck directory path in config file and presence of data.')
         return
 
-    # Make sure the derivatives folder exists:
-    derivatives_path = os.path.join(dataset_path, 'derivatives')
-    if not os.path.isdir(derivatives_path):
-        os.mkdir(derivatives_path)
-        print('___MEGqc___: Derivs folder was not found! Created new.')
+    output_root, derivatives_root = resolve_output_roots(dataset_path, derivatives_base)
 
     calculated_derivs_folder = os.path.join('derivatives', 'Meg_QC', 'calculation')
 
@@ -700,7 +721,8 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1):
     # REPLACE THE SELECTOR WITH A HARDCODED "ALL" CHOICE
     # --------------------------------------------------------------------------------
     # 1) Get all discovered entities from the derivatives scope
-    entities_found = get_ds_entities(dataset, calculated_derivs_folder)
+    with temporary_dataset_base(dataset, output_root):
+        entities_found = get_ds_entities(dataset, calculated_derivs_folder)
 
     # Suppose 'description' is the metric list
     all_metrics = entities_found.get('description', [])

--- a/meg_qc/run_megqc.py
+++ b/meg_qc/run_megqc.py
@@ -10,6 +10,12 @@ def run_megqc():
     dataset_path_parser = argparse.ArgumentParser(description= "parser for MEGqc: --inputdata(mandatory) path/to/your/BIDSds --config path/to/config  if None default parameters are used)")
     dataset_path_parser.add_argument("--inputdata", type=str, required=True, help="path to the root of your BIDS MEG dataset")
     dataset_path_parser.add_argument("--config", type=str, required=False, help="path to config file")
+    dataset_path_parser.add_argument(
+        "--derivatives_output",
+        type=str,
+        required=False,
+        help="Optional folder to store MEGqc derivatives outside the BIDS dataset",
+    )
     args=dataset_path_parser.parse_args()
 
     path_to_megqc_installation= os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir))
@@ -39,14 +45,20 @@ def run_megqc():
 
     internal_config_file_path=path_to_megqc_installation + '/settings/settings_internal.ini'
 
-    make_derivative_meg_qc(config_file_path, internal_config_file_path, data_directory)
+    make_derivative_meg_qc(config_file_path, internal_config_file_path, data_directory,
+                           derivatives_base=args.derivatives_output)
 
-    print('MEGqc has completed the calculation of metrics. Results can be found in' + data_directory +'/derivatives/MEGqc/calculation')
+    output_root = data_directory if args.derivatives_output is None else os.path.join(
+        args.derivatives_output,
+        os.path.basename(os.path.normpath(data_directory))
+    )
+    print('MEGqc has completed the calculation of metrics. Results can be found in ' +
+          os.path.join(output_root, 'derivatives', 'MEGqc', 'calculation'))
 
     user_input = input('Do you want to run the MEGqc plotting module on the MEGqc results? (y/n): ').lower().strip() == 'y'
 
     if user_input == True:
-        make_plots_meg_qc(data_directory)
+        make_plots_meg_qc(data_directory, derivatives_base=args.derivatives_output)
         return
     else:
         return

--- a/meg_qc/test.py
+++ b/meg_qc/test.py
@@ -279,11 +279,23 @@ def run_gqi():
         required=False,
         help="Path to a config file with GQI parameters",
     )
+    parser.add_argument(
+        "--derivatives_output",
+        type=str,
+        required=False,
+        help="Optional folder to store derivatives outside the BIDS dataset",
+    )
     args = parser.parse_args()
 
     install_path = os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir))
     default_config = os.path.join(install_path, "settings", "settings.ini")
     cfg_path = args.config if args.config else default_config
 
-    generate_gqi_summary(args.inputdata, cfg_path)
+    derivatives_root = args.derivatives_output
+    if derivatives_root:
+        derivatives_root = os.path.join(derivatives_root, os.path.basename(os.path.normpath(args.inputdata)), 'derivatives')
+    else:
+        derivatives_root = os.path.join(args.inputdata, 'derivatives')
+
+    generate_gqi_summary(args.inputdata, derivatives_root, cfg_path)
     return


### PR DESCRIPTION
## Summary
- route muscle artifact temporary and filtered files through the configured derivatives root instead of the BIDS input
- update muscle detection helpers to accept the dataset-specific derivatives directory and document the new parameter
- align pipeline call sites with the external derivatives option for muscle processing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936c2b509248326bc54eaa717edca5b)