### PR TITLE
Remove split FIF temp files during cleanup

### DIFF
--- a/meg_qc/calculation/meg_qc_pipeline.py
+++ b/meg_qc/calculation/meg_qc_pipeline.py
@@ -27,8 +27,13 @@ sys.path.append(os.path.join('..', '..', 'meg_qc', 'calculation'))
 sys.path.append(os.path.join('..', '..', '..', 'meg_qc', 'calculation'))
 sys.path.append(os.path.join('..', '..', '..', '..', 'meg_qc', 'calculation'))
 
-from meg_qc.calculation.initial_meg_qc import get_all_config_params, initial_processing, get_internal_config_params, \
-    delete_temp_folder
+from meg_qc.calculation.initial_meg_qc import (
+    delete_temp_folder,
+    get_all_config_params,
+    get_internal_config_params,
+    initial_processing,
+    remove_fif_and_splits,
+)
 # from meg_qc.plotting.universal_html_report import make_joined_report, make_joined_report_mne
 from meg_qc.plotting.universal_plots import QC_derivative
 
@@ -932,9 +937,9 @@ def process_one_subject(
 
         # CLEAN UP TEMP FILES
         try:
-            os.remove(raw_cropped)
-            os.remove(raw_cropped_filtered)
-            os.remove(raw_cropped_filtered_resampled)
+            remove_fif_and_splits(raw_cropped)
+            remove_fif_and_splits(raw_cropped_filtered)
+            remove_fif_and_splits(raw_cropped_filtered_resampled)
 
             del (meg_system, dict_epochs_mg, chs_by_lobe, channels,
                  raw_cropped_filtered, raw_cropped_filtered_resampled,
@@ -943,7 +948,7 @@ def process_one_subject(
                  lobes_color_coding_str, resample_str)
             gc.collect()
             print('REMOVING TRASH: SUCCEEDED')
-        except:
+        except Exception:
             print('REMOVING TRASH: FAILED')
 
     # WRITE DERIVATIVE

--- a/meg_qc/calculation/metrics/muscle_meg_qc.py
+++ b/meg_qc/calculation/metrics/muscle_meg_qc.py
@@ -31,7 +31,11 @@ import numpy as np
 from meg_qc.miscellaneous.optimizations.artifact_detection_ancp import annotate_muscle_zscore
 from typing import List
 from meg_qc.plotting.universal_plots import QC_derivative
-from meg_qc.calculation.initial_meg_qc import (load_data, save_meg_with_suffix)
+from meg_qc.calculation.initial_meg_qc import (
+    load_data,
+    remove_fif_and_splits,
+    save_meg_with_suffix,
+)
 
 def find_powerline_noise_short(raw, psd_params, psd_params_internal, m_or_g_chosen, channels):
 
@@ -502,5 +506,5 @@ def MUSCLE_meg_qc(
         derivatives_root,
     )
 
-    os.remove(raw_muscle_path)
+    remove_fif_and_splits(raw_muscle_path)
     return df_deriv, simple_metric, muscle_str_joined, scores_muscle

--- a/meg_qc/miscellaneous/optimizations/artifact_detection_ancp.py
+++ b/meg_qc/miscellaneous/optimizations/artifact_detection_ancp.py
@@ -5,7 +5,12 @@
 import gc
 import os
 import time
-from meg_qc.calculation.initial_meg_qc import (chs_dict_to_csv,load_data,save_meg_with_suffix)
+from meg_qc.calculation.initial_meg_qc import (
+    chs_dict_to_csv,
+    load_data,
+    remove_fif_and_splits,
+    save_meg_with_suffix,
+)
 import numpy as np
 from scipy.ndimage import distance_transform_edt, label
 from scipy.signal import find_peaks
@@ -181,7 +186,7 @@ def annotate_muscle_zscore(
     del raw
     del raw_copy
     gc.collect()
-    os.remove(raw_annotated_muscle_path)
+    remove_fif_and_splits(raw_annotated_muscle_path)
 
     return annot, scores_muscle
 


### PR DESCRIPTION
## Summary
- add helper to delete FIF split chunks created by MNE
- use split-aware cleanup for temporary MEG outputs
- ensure muscle artifact helpers remove split files

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939714cbe14832695a87064a94d1f9d)