### PR TITLE
Handle external derivatives paths in plotting

### DIFF
--- a/meg_qc/calculation/meg_qc_pipeline.py
+++ b/meg_qc/calculation/meg_qc_pipeline.py
@@ -77,7 +77,23 @@ def resolve_output_roots(dataset_path: str, external_derivatives_root: Optional[
     """
 
     ds_name = os.path.basename(os.path.normpath(dataset_path))
-    output_root = dataset_path if external_derivatives_root is None else os.path.join(external_derivatives_root, ds_name)
+
+    if external_derivatives_root is None:
+        output_root = dataset_path
+    else:
+        external_root = os.path.normpath(external_derivatives_root)
+
+        # Accept three possible shapes for ``external_root``:
+        # 1) a base folder where MEGqc should create ``<ds_name>/derivatives``
+        # 2) the dataset root itself (already containing ``derivatives``)
+        # 3) the derivatives folder directly
+        if os.path.basename(external_root) == 'derivatives':
+            output_root = os.path.dirname(external_root)
+        elif os.path.isdir(os.path.join(external_root, 'derivatives')):
+            output_root = external_root
+        else:
+            output_root = os.path.join(external_root, ds_name)
+
     derivatives_root = os.path.join(output_root, 'derivatives')
     os.makedirs(derivatives_root, exist_ok=True)
     return output_root, derivatives_root

--- a/meg_qc/plotting/meg_qc_plots.py
+++ b/meg_qc/plotting/meg_qc_plots.py
@@ -82,7 +82,23 @@ def resolve_output_roots(dataset_path: str, external_derivatives_root: Optional[
     """Return dataset output root and derivatives folder respecting overrides."""
 
     ds_name = os.path.basename(os.path.normpath(dataset_path))
-    output_root = dataset_path if external_derivatives_root is None else os.path.join(external_derivatives_root, ds_name)
+
+    if external_derivatives_root is None:
+        output_root = dataset_path
+    else:
+        external_root = os.path.normpath(external_derivatives_root)
+
+        # Accept three possible shapes for ``external_root``:
+        # 1) a base folder where MEGqc should create ``<ds_name>/derivatives``
+        # 2) the dataset root itself (already containing ``derivatives``)
+        # 3) the derivatives folder directly
+        if os.path.basename(external_root) == 'derivatives':
+            output_root = os.path.dirname(external_root)
+        elif os.path.isdir(os.path.join(external_root, 'derivatives')):
+            output_root = external_root
+        else:
+            output_root = os.path.join(external_root, ds_name)
+
     derivatives_root = os.path.join(output_root, 'derivatives')
     os.makedirs(derivatives_root, exist_ok=True)
     return output_root, derivatives_root


### PR DESCRIPTION
## Summary
- expand derivatives path resolution to accept dataset roots and derivatives folders when plotting or calculating
- align plotting and calculation helpers so GUI, CLI, and examples can reuse external derivatives paths consistently

## Testing
- pytest tests/test_meg_pipeline.py::MegPipelineTest::test_run_pipeline *(fails: test not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c095c8d288326992958b58074946c)