### PR TITLE
Handle plotting entity queries when derivatives not found

### DIFF
--- a/meg_qc/create_plots.py
+++ b/meg_qc/create_plots.py
@@ -1,18 +1,44 @@
-import os
+"""Command-line helper to run the plotting module."""
+
 import argparse
 
-def get_plots():
-    from meg_qc.plotting.meg_qc_plots import make_plots_meg_qc
+from meg_qc.calculation.meg_qc_pipeline import resolve_output_roots
+from meg_qc.plotting.meg_qc_plots import make_plots_meg_qc
 
-    dataset_path_parser = argparse.ArgumentParser(description= "parser for MEGqc: --inputdata(mandatory) path/to/your/BIDSds)")
-    dataset_path_parser.add_argument("--inputdata", type=str, required=True, help="path to the root of your BIDS MEG dataset")
-    args=dataset_path_parser.parse_args()
+
+def get_plots() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the MEGqc plotting module: --inputdata <BIDS ds> [--derivatives_output <folder>]"
+        )
+    )
+    parser.add_argument(
+        "--inputdata",
+        type=str,
+        required=True,
+        help="Path to the root of your BIDS MEG dataset",
+    )
+    parser.add_argument(
+        "--derivatives_output",
+        type=str,
+        required=False,
+        help=(
+            "Optional folder to store derivatives outside the BIDS dataset. "
+            "A subfolder named after the dataset will be created automatically."
+        ),
+    )
+    args = parser.parse_args()
+
     data_directory = args.inputdata
+    derivatives_base = args.derivatives_output
 
-    print(data_directory)
-    print(type(data_directory))
+    # Mirror the calculation pipeline: resolve the concrete derivatives root and
+    # log it so users can verify exactly where plotting reads results from.
+    _, derivatives_root = resolve_output_roots(data_directory, derivatives_base)
+    print(f"___MEGqc___: Reading derivatives from: {derivatives_root}")
 
-    make_plots_meg_qc(data_directory)
+    make_plots_meg_qc(data_directory, derivatives_base=derivatives_base)
 
 
-get_plots()
+if __name__ == "__main__":
+    get_plots()

--- a/meg_qc/plotting/meg_qc_plots.py
+++ b/meg_qc/plotting/meg_qc_plots.py
@@ -265,7 +265,7 @@ def select_subcategory(subcategories: List, category_title: str, window_title: s
     return results, quit_selector
 
 
-def get_ds_entities(dataset, calculated_derivs_folder: str):
+def get_ds_entities(dataset, calculated_derivs_folder: str, output_root: str):
 
     """
     Get the entities of the dataset using ancpbids, only get derivative entities, not all raw data.
@@ -276,6 +276,9 @@ def get_ds_entities(dataset, calculated_derivs_folder: str):
         The dataset object.
     calculated_derivs_folder : str
         The path to the calculated derivatives folder.
+    output_root : str
+        Base directory where derivatives are stored (may differ from the
+        original BIDS dataset when users provide an external location).
 
     Returns
     -------
@@ -284,12 +287,37 @@ def get_ds_entities(dataset, calculated_derivs_folder: str):
 
     """
 
-    try:
-        entities = dataset.query_entities(scope=calculated_derivs_folder)
-        print('___MEGqc___: ', 'Entities found in the dataset: ', entities)
-        #we only get entities of calculated derivatives here, not entire raw ds.
-    except:
+    original_base = getattr(dataset, 'base_dir_', None)
+
+    def _safe_query_entities():
+        """Query entities while tolerating empty results/Windows ``None`` returns."""
+
+        try:
+            return dataset.query_entities(scope=calculated_derivs_folder) or {}
+        except TypeError:
+            # ``query_entities`` can raise ``TypeError`` when ``query`` returns
+            # ``None`` (e.g., when a derivatives folder does not exist yet on
+            # some platforms). Treat that situation as an empty mapping so we
+            # can try fallbacks before failing.
+            return {}
+
+    # First, try querying in the resolved output root (covers external derivatives).
+    with temporary_dataset_base(dataset, output_root):
+        entities = _safe_query_entities()
+
+    # If nothing was found and the output root differs from the original dataset
+    # location, try again with the original base. This keeps legacy behaviour
+    # where derivatives live inside the BIDS tree while still supporting external
+    # outputs.
+    if not entities and original_base not in (None, output_root):
+        with temporary_dataset_base(dataset, original_base):
+            entities = _safe_query_entities()
+
+    if not entities:
         raise FileNotFoundError(f'___MEGqc___: No calculated derivatives found for this ds!')
+
+    print('___MEGqc___: ', 'Entities found in the dataset: ', entities)
+    # we only get entities of calculated derivatives here, not entire raw ds.
 
     return entities
 
@@ -617,78 +645,79 @@ def process_subject(
         derivs_to_plot: list,
         chosen_entities: dict,
         plot_settings: dict,
+        output_root: str,
 ):
     """Plot all metrics for a single subject."""
 
-    derivative = dataset.create_derivative(name="Meg_QC")
-    derivative.dataset_description.GeneratedBy.Name = "MEG QC Pipeline"
-    reports_folder = derivative.create_folder(name='reports')
-    subject_folder = reports_folder.create_folder(name='sub-' + sub)
-
-    existing_raws_per_sub = list(set(
-        d.raw_entity_name for d in derivs_to_plot if d.subject == sub
-    ))
-
-    for raw_entity_name in existing_raws_per_sub:
-        derivs_for_this_raw = [
-            d for d in derivs_to_plot if d.raw_entity_name == raw_entity_name
-        ]
-
-        raw_entities_base = derivs_for_this_raw[0].deriv_entity_obj
-
-        raw_info_path = None
-        report_str_path = None
-        simple_metrics_path = None
-        for d in derivs_for_this_raw:
-            if d.metric == 'RawInfo':
-                raw_info_path = d.path
-            elif d.metric == 'ReportStrings':
-                report_str_path = d.path
-            elif d.metric == 'SimpleMetrics':
-                simple_metrics_path = d.path
-
-        metrics_to_plot = [
-            m for m in chosen_entities['METRIC']
-            if m not in ['RawInfo', 'ReportStrings', 'SimpleMetrics']
-        ]
-
-        for metric in metrics_to_plot:
-            tsv_paths = [d.path for d in derivs_for_this_raw if d.metric == metric]
-            if not tsv_paths:
-                print(f'___MEGqc___: No tsvs found for {metric} / subject {sub}')
-                continue
-
-            tsvs_for_this_raw = [d for d in derivs_for_this_raw if d.metric == metric]
-            raw_entities_to_write = tsvs_for_this_raw[0].deriv_entity_obj
-
-            html_report = csv_to_html_report(
-                raw_info_path,
-                metric,
-                tsv_paths,
-                report_str_path,
-                plot_settings,
-            )
-
-            meg_artifact = subject_folder.create_artifact(raw=raw_entities_to_write)
-            meg_artifact.add_entity('desc', metric)
-            meg_artifact.suffix = 'meg'
-            meg_artifact.extension = '.html'
-
-            meg_artifact.content = lambda file_path, rep=html_report: rep.save(
-                file_path, overwrite=True, open_browser=False
-            )
-
-        if report_str_path and simple_metrics_path:
-            summary_html = make_summary_qc_report(report_str_path, simple_metrics_path)
-            meg_artifact = subject_folder.create_artifact(raw=raw_entities_base)
-            meg_artifact.add_entity('desc', 'summary_qc_report')
-            meg_artifact.suffix = 'meg'
-            meg_artifact.extension = '.html'
-            meg_artifact.content = (
-                lambda file_path, cont=summary_html: open(file_path, "w", encoding="utf-8").write(cont)
-            )
-
     with temporary_dataset_base(dataset, output_root):
+        derivative = dataset.create_derivative(name="Meg_QC")
+        derivative.dataset_description.GeneratedBy.Name = "MEG QC Pipeline"
+        reports_folder = derivative.create_folder(name='reports')
+        subject_folder = reports_folder.create_folder(name='sub-' + sub)
+
+        existing_raws_per_sub = list(set(
+            d.raw_entity_name for d in derivs_to_plot if d.subject == sub
+        ))
+
+        for raw_entity_name in existing_raws_per_sub:
+            derivs_for_this_raw = [
+                d for d in derivs_to_plot if d.raw_entity_name == raw_entity_name
+            ]
+
+            raw_entities_base = derivs_for_this_raw[0].deriv_entity_obj
+
+            raw_info_path = None
+            report_str_path = None
+            simple_metrics_path = None
+            for d in derivs_for_this_raw:
+                if d.metric == 'RawInfo':
+                    raw_info_path = d.path
+                elif d.metric == 'ReportStrings':
+                    report_str_path = d.path
+                elif d.metric == 'SimpleMetrics':
+                    simple_metrics_path = d.path
+
+            metrics_to_plot = [
+                m for m in chosen_entities['METRIC']
+                if m not in ['RawInfo', 'ReportStrings', 'SimpleMetrics']
+            ]
+
+            for metric in metrics_to_plot:
+                tsv_paths = [d.path for d in derivs_for_this_raw if d.metric == metric]
+                if not tsv_paths:
+                    print(f'___MEGqc___: No tsvs found for {metric} / subject {sub}')
+                    continue
+
+                tsvs_for_this_raw = [d for d in derivs_for_this_raw if d.metric == metric]
+                raw_entities_to_write = tsvs_for_this_raw[0].deriv_entity_obj
+
+                html_report = csv_to_html_report(
+                    raw_info_path,
+                    metric,
+                    tsv_paths,
+                    report_str_path,
+                    plot_settings,
+                )
+
+                meg_artifact = subject_folder.create_artifact(raw=raw_entities_to_write)
+                meg_artifact.add_entity('desc', metric)
+                meg_artifact.suffix = 'meg'
+                meg_artifact.extension = '.html'
+
+                meg_artifact.content = lambda file_path, rep=html_report: rep.save(
+                    file_path, overwrite=True, open_browser=False
+                )
+
+            if report_str_path and simple_metrics_path:
+                summary_html = make_summary_qc_report(report_str_path, simple_metrics_path)
+                meg_artifact = subject_folder.create_artifact(raw=raw_entities_base)
+                meg_artifact.add_entity('desc', 'summary_qc_report')
+                meg_artifact.suffix = 'meg'
+                meg_artifact.extension = '.html'
+                meg_artifact.content = (
+                    lambda file_path, cont=summary_html: open(file_path, "w", encoding="utf-8").write(cont)
+                )
+
         ancpbids.write_derivative(dataset, derivative)
     return
 
@@ -714,6 +743,7 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1, derivatives_base: Opti
         return
 
     output_root, derivatives_root = resolve_output_roots(dataset_path, derivatives_base)
+    print(f"___MEGqc___: Reading derivatives from: {derivatives_root}")
 
     calculated_derivs_folder = os.path.join('derivatives', 'Meg_QC', 'calculation')
 
@@ -721,8 +751,7 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1, derivatives_base: Opti
     # REPLACE THE SELECTOR WITH A HARDCODED "ALL" CHOICE
     # --------------------------------------------------------------------------------
     # 1) Get all discovered entities from the derivatives scope
-    with temporary_dataset_base(dataset, output_root):
-        entities_found = get_ds_entities(dataset, calculated_derivs_folder)
+    entities_found = get_ds_entities(dataset, calculated_derivs_folder, output_root)
 
     # Suppose 'description' is the metric list
     all_metrics = entities_found.get('description', [])
@@ -817,12 +846,14 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1, derivatives_base: Opti
         if chosen_entities['run']:
             query_args['run'] = chosen_entities['run']
 
-        tsv_paths = list(dataset.query(**query_args))
+        with temporary_dataset_base(dataset, output_root):
+            tsv_paths = list(dataset.query(**query_args))
         tsvs_to_plot_by_metric[metric] = sorted(tsv_paths)
 
         # Now query object form for ancpbids entities
         query_args['return_type'] = 'object'
-        entities_obj = sorted(list(dataset.query(**query_args)), key=lambda k: k['name'])
+        with temporary_dataset_base(dataset, output_root):
+            entities_obj = sorted(list(dataset.query(**query_args)), key=lambda k: k['name'])
         tsv_entities_by_metric[metric] = entities_obj
 
     # Convert them into a list of Deriv_to_plot objects
@@ -855,6 +886,7 @@ def make_plots_meg_qc(dataset_path: str, n_jobs: int = 1, derivatives_base: Opti
             derivs_to_plot=derivs_to_plot,
             chosen_entities=chosen_entities,
             plot_settings=plot_settings,
+            output_root=output_root,
         )
         for sub in chosen_entities['subject']
     )


### PR DESCRIPTION
## Summary
- add tolerant plotting entity query handling for missing derivatives directories
- fallback to original BIDS base when resolved output root contains no entities
- keep logging of detected entities after successful lookup

## Testing
- python -m compileall meg_qc/plotting/meg_qc_plots.py meg_qc/create_plots.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fe254f10c832687d5751f41358276)