### PR TITLE
Support external derivatives via overlay for plotting

### DIFF
--- a/meg_qc/create_plots.py
+++ b/meg_qc/create_plots.py
@@ -1,18 +1,44 @@
-import os
+"""Command-line helper to run the plotting module."""
+
 import argparse
 
-def get_plots():
-    from meg_qc.plotting.meg_qc_plots import make_plots_meg_qc
+from meg_qc.calculation.meg_qc_pipeline import resolve_output_roots
+from meg_qc.plotting.meg_qc_plots import make_plots_meg_qc
 
-    dataset_path_parser = argparse.ArgumentParser(description= "parser for MEGqc: --inputdata(mandatory) path/to/your/BIDSds)")
-    dataset_path_parser.add_argument("--inputdata", type=str, required=True, help="path to the root of your BIDS MEG dataset")
-    args=dataset_path_parser.parse_args()
+
+def get_plots() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the MEGqc plotting module: --inputdata <BIDS ds> [--derivatives_output <folder>]"
+        )
+    )
+    parser.add_argument(
+        "--inputdata",
+        type=str,
+        required=True,
+        help="Path to the root of your BIDS MEG dataset",
+    )
+    parser.add_argument(
+        "--derivatives_output",
+        type=str,
+        required=False,
+        help=(
+            "Optional folder to store derivatives outside the BIDS dataset. "
+            "A subfolder named after the dataset will be created automatically."
+        ),
+    )
+    args = parser.parse_args()
+
     data_directory = args.inputdata
+    derivatives_base = args.derivatives_output
 
-    print(data_directory)
-    print(type(data_directory))
+    # Mirror the calculation pipeline: resolve the concrete derivatives root and
+    # log it so users can verify exactly where plotting reads results from.
+    _, derivatives_root = resolve_output_roots(data_directory, derivatives_base)
+    print(f"___MEGqc___: Reading derivatives from: {derivatives_root}")
 
-    make_plots_meg_qc(data_directory)
+    make_plots_meg_qc(data_directory, derivatives_base=derivatives_base)
 
 
-get_plots()
+if __name__ == "__main__":
+    get_plots()


### PR DESCRIPTION
## Summary
- create a temporary overlay dataset so ANCPBIDS can discover derivatives stored outside the original BIDS tree
- route plotting queries through the overlay while still writing outputs to the resolved derivatives root
- clean up overlay resources after plotting completes

## Testing
- python -m compileall meg_qc/plotting/meg_qc_plots.py meg_qc/create_plots.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fe254f10c832687d5751f41358276)