### PR TITLE
Fallback to fixed epochs when events are scarce

### DIFF
--- a/docs/source/settings_ini.rst
+++ b/docs/source/settings_ini.rst
@@ -54,6 +54,9 @@ Epoching [Epoching]
 - **epoch_tmax** (float) : time in seconds after the event. Unit: sec. Default: 1
 - **stim_channel** (str) : leave blank if want it to be detected automatically or write explicitely like *STI101*. Default:  * blank *. 
 - **event_repeated** (str) : how to handle duplicates in events[:, 0]. Can be 'error' to raise an error, ‘drop’ to only retain the row occurring first in the events, or 'merge' to combine the coinciding events (=duplicates) into a new event (see Notes for details). Default: *merge*
+- **use_fixed_length_epochs** (bool) : if True and no stimulus channels are detected or fewer than 2 events are found, epoch the data into fixed-length segments. Default: *True*
+- **fixed_epoch_duration** (float) : length of fixed epochs in seconds. Used only when fixed-length epoching is enabled. Default: *2.0*
+- **fixed_epoch_overlap** (float) : overlap between consecutive fixed epochs in seconds. Must be smaller than duration. Default: *0.0*
 
 Standard deviation [STD]
 ------------------------
@@ -137,5 +140,4 @@ Muscle artifacts [Muscle]
 - **min_distance_between_different_muscle_events** (int or float) : minimum distance between different muscle events in seconds. If events happen closer to each other they will all be counted as one event and the time will be assigned as the first peak. Unit: seconds. Default: *1*  
 
 Difference between last 2 settings: **min_length_good** - used to detect ALL muscle events, **min_distance_between_different_muscle_events** - used to detect evets with z-score higher than the threshold on base of ALL muscle events
-
 

--- a/meg_qc/calculation/initial_meg_qc.py
+++ b/meg_qc/calculation/initial_meg_qc.py
@@ -363,6 +363,7 @@ def Epoch_meg(epoching_params, data: mne.io.Raw):
     use_fixed_length_epochs = epoching_params['use_fixed_length_epochs']
     fixed_epoch_duration = epoching_params['fixed_epoch_duration']
     fixed_epoch_overlap = epoching_params['fixed_epoch_overlap']
+    min_event_count = 2 if use_fixed_length_epochs else 1
 
     if stim_channel is None:
         picks_stim = mne.pick_types(data.info, stim=True)
@@ -426,9 +427,10 @@ def Epoch_meg(epoching_params, data: mne.io.Raw):
         try:
             events = mne.find_events(data, stim_channel=stim_channel, min_duration=event_dur)
 
-            if len(events) < 1:
+            if len(events) < min_event_count:
                 _apply_fixed_length_fallback(
-                    'No events with set minimum duration were found using all stimulus channels.'
+                    f'Only {len(events)} event(s) were found using all stimulus channels '
+                    f'(minimum required: {min_event_count}).'
                 )
             else:
                 print('___MEGqc___: ', 'Events found:', len(events))

--- a/meg_qc/settings/settings.ini
+++ b/meg_qc/settings/settings.ini
@@ -68,7 +68,7 @@ epoch_tmax = 1
 stim_channel = 
 # event_repeated (str) - How to handle duplicates in events[:, 0]. Can be 'error' to raise an error, ‘drop’ to only retain the row occurring first in the events, or 'merge' to combine the coinciding events (=duplicates) into a new event (see Notes for details).
 event_repeated = merge
-# use_fixed_length_epochs (bool) - If True and no stimulus channels are detected, epoch the data into fixed-length segments.
+# use_fixed_length_epochs (bool) - If True and no stimulus channels are detected or too few events are found, epoch the data into fixed-length segments.
 use_fixed_length_epochs = True
 # fixed_epoch_duration (float) - Length of fixed epochs in seconds (used only when use_fixed_length_epochs = True).
 fixed_epoch_duration = 2.0


### PR DESCRIPTION
### Motivation
- Make epoching more robust when stimulus events are present but too few to produce meaningful stimulus-locked epochs by falling back to fixed-length epochs when configured to do so.

### Description
- In `Epoch_meg` (`meg_qc/calculation/initial_meg_qc.py`) add a `min_event_count` (requires 2 events when `use_fixed_length_epochs` is `True`, otherwise 1) and trigger the fixed-length fallback when fewer events are found, including a clearer status message with the found vs required counts.
- Clarify the `use_fixed_length_epochs` comment in `meg_qc/settings/settings.ini` to indicate fixed-length fallback also triggers when too few events are found.
- Document the fixed-length epoching behavior and parameters in `docs/source/settings_ini.rst` by adding `use_fixed_length_epochs`, `fixed_epoch_duration`, and `fixed_epoch_overlap` entries.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e397440848326aa3f9d4a34bfa596)