### PR TITLE
Fix fixed-length epoch picks handling

### DIFF
--- a/meg_qc/calculation/initial_meg_qc.py
+++ b/meg_qc/calculation/initial_meg_qc.py
@@ -404,9 +404,10 @@ def Epoch_meg(epoching_params, data: mne.io.Raw):
             data,
             duration=fixed_epoch_duration,
             overlap=fixed_epoch_overlap,
-            picks=picks,
             preload=True,
             baseline=None)
+        if picks:
+            epochs.pick(picks)
         print('___MEGqc___: ',
               f'Fixed-length epochs created for {channel_type}: {len(epochs)} epochs.')
         return epochs


### PR DESCRIPTION
### Motivation
- Prevent a runtime error when falling back to fixed-length epochs because `mne.make_fixed_length_epochs()` does not accept a `picks` argument on some MNE versions while still applying channel selection.

### Description
- Remove the unsupported `picks` keyword from the `mne.make_fixed_length_epochs` call and instead apply channel selection after epoch creation with `epochs.pick(picks)` when `picks` is provided.
- Change applied in `meg_qc/calculation/initial_meg_qc.py` inside the `_make_fixed_length_epochs` helper to preserve existing duration/overlap validation and logging.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698066a3d7c083268c08229cb2a932dc)