### PR TITLE
Register fixed EOG channels as `eog` types before detection

### DIFF
--- a/meg_qc/calculation/metrics/ECG_EOG_meg_qc.py
+++ b/meg_qc/calculation/metrics/ECG_EOG_meg_qc.py
@@ -1606,6 +1606,8 @@ def get_EOG_data(raw: mne.io.Raw, eog_params: dict):
         missing = [name for name in fixed_eog_names if name not in raw.ch_names]
         if missing:
             print('___MEGqc___: EOG fixed channels not found in data:', missing)
+        if eog_channel_names:
+            raw.set_channel_types({name: 'eog' for name in eog_channel_names})
     else:
         # Select the EOG channels
         eog_channels = mne.pick_types(raw.info, meg=False, eeg=False, stim=False, eog=True)


### PR DESCRIPTION
### Motivation
- Fixed EOG channel names provided in the config were not registered as `eog` channel types, causing MNE's EOG detection to miss them and raise "No EOG channel(s) found" errors.

### Description
- If `fixed_channel_names` are present and found in `raw.ch_names`, mark those channels as `eog` using `raw.set_channel_types({name: 'eog' for name in eog_channel_names})` before calling `mne.preprocessing.find_eog_events`.

### Testing
- No automated tests were run for this change; the edit is small and relies on existing logging to verify behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983508ad58c83268ccd73cd2377cbfa)